### PR TITLE
Added Cmake FindPackage invocations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules
 find_package(OpenGL)
 find_package(GLFW)
 
+#If on OSX check for Macports
+if(APPLE)
+  include_directories("/opt/local/include")
+  link_directories("/opt/local/lib")
+endif()
+
 LINK_DIRECTORIES( ${CMAKE_SOURCE_DIR}/lib )
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,18 +2,36 @@ cmake_minimum_required (VERSION 2.6)
 
 project (SuperBible6)
 
+#Sets the directory for cmake to find Cmake configration packages,
+#these packages allow for cmake to find libraries that are not included
+#in the standard installation of Cmake. The standard packages can be
+#found @ /usr/share/cmake-2.8/Modules (on Unix Machines)
+set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules
+                      ${CMAKE_MODULE_PATH})
+
+#Attempt to search for the necessary Library requirements
+find_package(OpenGL)
+find_package(GLFW)
+
 LINK_DIRECTORIES( ${CMAKE_SOURCE_DIR}/lib )
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-if(WIN32)
-set(COMMON_LIBS sb6 optimized GLFW_r32 debug GLFW_d32)
-elif (UNIX)
-set(COMMON_LIBS sb6 glfw ${GLFW_LIBRARIES} GL rt dl)
+#If we found the two libraries 
+if(${OPENGL_FOUND} STREQUAL "TRUE" AND ${GLFW_FOUND} STREQUAL "YES")
+	include_directories(${OPENGL_INCLUDE_DIR})
+	include_directories(${GLFW_INCLUDE_DIR})
+	set(COMMON_LIBS sb6 ${OPENGL_LIBRARIES} ${GLFW_LIBRARY})
 else()
-set(COMMON_LIBS sb6)
+	if(WIN32)
+		set(COMMON_LIBS sb6 optimized GLFW_r32 debug GLFW_d32)
+	elif (UNIX)
+		set(COMMON_LIBS sb6 glfw ${GLFW_LIBRARIES} GL rt dl)
+	else()
+		set(COMMON_LIBS sb6)
+	endif()
 endif()
 
 IF(APPLE)

--- a/cmake/modules/FindGLFW.cmake
+++ b/cmake/modules/FindGLFW.cmake
@@ -1,0 +1,70 @@
+# Locate the glfw library
+# This module defines the following variables:
+# GLFW_LIBRARY, the name of the library;
+# GLFW_INCLUDE_DIR, where to find glfw include files.
+# GLFW_FOUND, true if both the GLFW_LIBRARY and GLFW_INCLUDE_DIR have been found.
+#
+# To help locate the library and include file, you could define an environment variable called
+# GLFW_ROOT which points to the root of the glfw library installation. This is pretty useful
+# on a Windows platform.
+#
+#
+# Usage example to compile an "executable" target to the glfw library:
+#
+# FIND_PACKAGE (glfw REQUIRED)
+# INCLUDE_DIRECTORIES (${GLFW_INCLUDE_DIR})
+# ADD_EXECUTABLE (executable ${EXECUTABLE_SRCS})
+# TARGET_LINK_LIBRARIES (executable ${GLFW_LIBRARY})
+#
+# TODO:
+# Allow the user to select to link to a shared library or to a static library.
+
+#Search for the include file...
+FIND_PATH(GLFW_INCLUDE_DIR GL/glfw.h DOC "Path to GLFW include directory."
+  HINTS
+  $ENV{GLFW_ROOT}
+  PATH_SUFFIX include
+  PATHS
+  /usr/include/
+  /usr/local/include/
+  # By default headers are under GL subfolder
+  /usr/include/GL
+  /usr/local/include/GL
+  ${GLFW_ROOT_DIR}/include/ # added by ptr
+)
+
+FIND_LIBRARY(GLFW_LIBRARY_TEMP DOC "Absolute path to GLFW library."
+  NAMES glfw GLFW.lib
+  HINTS
+  $ENV{GLFW_ROOT}
+  # In the expanded GLFW source archive. Should be uncommon, but whatever.
+  PATH_SUFFIXES lib/win32 lib/cocoa lib/x11
+  PATHS
+  /usr/local/lib
+  /usr/lib
+  ${GLFW_ROOT_DIR}/lib-msvc100/release # added by ptr
+)
+
+SET(GLFW_FOUND "NO")
+IF(GLFW_LIBRARY_TEMP AND GLFW_INCLUDE_DIR)
+  SET(GLFW_FOUND "YES")
+  message(STATUS "Found GLFW: ${GLFW_LIBRARY_TEMP}")
+
+  # For MinGW library
+  IF(MINGW)
+    SET(MINGW32_LIBRARY mingw32 CACHE STRING "mwindows for MinGW")
+    SET(GLFW_LIBRARY_TEMP ${MINGW32_LIBRARY} ${GLFW_LIBRARY_TEMP})
+  ENDIF(MINGW)
+
+  # OS X uses the Cocoa port so we need to link against Cocoa
+  IF(APPLE)
+    SET(GLFW_LIBRARY_TEMP ${GLFW_LIBRARY_TEMP} "-framework Cocoa -framework IOKit")
+    SET(GLFW_LIBRARY ${GLFW_LIBRARY_TEMP})
+  ENDIF(APPLE)
+
+  # Set the final string here so the GUI reflects the final state.
+  SET(GLFW_LIBRARY ${GLFW_LIBRARY_TEMP} CACHE STRING "Where the GLFW Library can be found")
+  # Set the temp variable to INTERNAL so it is not seen in the CMake GUI
+  SET(GLFW_LIBRARY_TEMP "" CACHE INTERNAL "")
+ENDIF(GLFW_LIBRARY_TEMP AND GLFW_INCLUDE_DIR)
+


### PR DESCRIPTION
Since many different machines place libraries in different locations, the Find_Package() calls will attempt to find the installed versions on the system. If they are NOT available then revert back to the old configuration.
