### PR TITLE
cmake syntax error?

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
 if(WIN32)
 set(COMMON_LIBS sb6 optimized GLFW_r32 debug GLFW_d32)
-elif (UNIX)
+elseif (UNIX)
 set(COMMON_LIBS sb6 glfw ${GLFW_LIBRARIES} GL rt dl)
 else()
 set(COMMON_LIBS sb6)


### PR DESCRIPTION
the cmake script ran fine on my mac (which ironically doesn't support opengl 4.3)
when running cmake on windows for vs2010 it bombed at the elif.  i changed elif to elseif and now it runs.
