### PR TITLE
Changes for migrating to glfw3.0.4 for the sb6 classes

### DIFF
--- a/include/sb6.h
+++ b/include/sb6.h
@@ -238,7 +238,7 @@ public:
 
     }
 
-    virtual void onMouseWheel(int pos)
+    virtual void onMouseWheel(double pos1, double pos2)
     {
 
     }


### PR DESCRIPTION
The attached patch for sb6.h migrates sb6 classes to use glfw3.0.4 package. Build tested with Visual Studio 2012 on Windows 7, with glfw3.0.4 and sb6code.
