### PR TITLE
glUniform1f() wrongly assumes that exposure is uniform 0.  Using glGetUn...

### DIFF
--- a/src/ktxview/ktxview.cpp
+++ b/src/ktxview/ktxview.cpp
@@ -112,6 +112,8 @@ public:
 
         glLinkProgram(program);
 
+        exposure = glGetUniformLocation(program, "exposure");
+
         glGenVertexArrays(1, &vao);
         glBindVertexArray(vao);
     }
@@ -130,13 +132,14 @@ public:
 
         glUseProgram(program);
         glViewport(0, 0, info.windowWidth, info.windowHeight);
-        glUniform1f(0, (float)(sin(t) * 16.0 + 16.0));
+        glUniform1f(exposure, (float)(sin(t) * 16.0 + 16.0));
         glDrawArrays(GL_TRIANGLE_STRIP, 0, 4);
     }
 
 private:
     GLuint      texture;
     GLuint      program;
+    GLuint      exposure;
     GLuint      vao;
 };
 


### PR DESCRIPTION
...iformLocation() instead and store the result in a member value.

---

Also, the latest media uses a file called Tree.ktx with a capital 'T' when the source code expects tree.ktx.  This doesn't work under Linux (and probably Mac).
